### PR TITLE
Add metadata to English howtos

### DIFF
--- a/howto/en/cloudflare-simple-API-worker-EN.md
+++ b/howto/en/cloudflare-simple-API-worker-EN.md
@@ -1,3 +1,11 @@
+---
+title: Counter API with Cloudflare Workers
+lang: en
+tags: [cloudflare, api, rest]
+created: 2024-10-12
+updated: 2025-07-27
+---
+
 
 # 🚀 Mini Guide — Counter API with Cloudflare Workers
 
@@ -9,6 +17,16 @@ Build a REST API using Cloudflare Workers with:
 - KV storage backend
 - Auto-generated OpenAPI spec
 - Full CORS support for frontend usage (SPA, mini-game...)
+## 🧰 Requirements
+
+### 🖥️ Environment
+- Recommended OS: Linux / macOS / Windows WSL
+- Cloudflare account
+
+### 📦 Required tools
+- Node.js & npm
+- Wrangler CLI
+
 
 ## 🛠️ Tech Stack
 

--- a/howto/en/github-deploy-via-ftp-EN.md
+++ b/howto/en/github-deploy-via-ftp-EN.md
@@ -1,10 +1,21 @@
+---
+title: Deploy a Static Website from GitHub via FTP
+lang: en
+tags: [git, ftp, deployment, github-actions]
+created: 2024-10-12
+updated: 2025-07-27
+---
+
 # 🚀 How to Deploy a Static Website from GitHub via FTP
 
-Automatically deploying a static website to a remote server via FTP can greatly simplify your publishing workflow. In this guide, we’ll configure a **GitHub Action** to upload the contents of a folder (e.g., `www`) to an FTP server on every push to the `main` branch.
+## 🎯 Goal
+
+Automatically deploy a static website to a remote server via FTP on every push to GitHub.
+
 
 ---
 
-## 🧰 Prerequisites
+## 🧰 Requirements
 
 Before getting started, make sure you have:
 

--- a/howto/en/stow_dotfiles_howto_EN.md
+++ b/howto/en/stow_dotfiles_howto_EN.md
@@ -1,12 +1,23 @@
-# Practical Guide: Managing Dotfiles with Git and GNU Stow
+---
+title: Practical Guide: Managing Dotfiles with Git and GNU Stow
+lang: en
+tags: [git, dotfiles, stow]
+created: 2024-10-12
+updated: 2025-07-27
+---
 
-## Goal
+# 🚀 Practical Guide: Managing Dotfiles with Git and GNU Stow
+
+## 🎯 Goal
 
 This how‑to shows how to centralize and deploy your personal configuration files (dotfiles) using a **Git** repository together with **GNU Stow** so you can share them effortlessly across machines.
 
-## Prerequisites
+## 🧰 Requirements
+### 🖥️ Environment
+- Recommended OS: Linux / macOS / Windows WSL
 
-### Required tools
+
+### 📦 Required tools
 
 - **git**
 - **stow**

--- a/howto/fr/cloudflare-simple-API-worker-FR.md
+++ b/howto/fr/cloudflare-simple-API-worker-FR.md
@@ -1,3 +1,10 @@
+---
+title: API REST de compteur avec Cloudflare Workers
+lang: fr
+tags: [cloudflare, api, rest]
+created: 2025-07-27
+updated: 2025-07-27
+---
 
 # 🚀 Mini Guide — API REST de compteur avec Cloudflare Workers
 

--- a/howto/fr/github-deploy-via-ftp-FR.md
+++ b/howto/fr/github-deploy-via-ftp-FR.md
@@ -1,6 +1,16 @@
+---
+title: Déployer un site statique depuis GitHub via FTP
+lang: fr
+tags: [ftp, déploiement, github-actions]
+created: 2025-07-27
+updated: 2025-07-27
+---
+
 # 🚀 Déployer un site statique depuis GitHub via FTP
 
-Déployer automatiquement un site statique vers un serveur FTP peut grandement simplifier vos workflows de publication. Dans ce guide, nous allons configurer une **GitHub Action** pour envoyer le contenu d’un dossier (`www` par exemple) vers un serveur distant à chaque *push* sur la branche `main`.
+## 🎯 Objectif
+
+Configurer **GitHub Actions** pour publier automatiquement le contenu du dossier `www/` sur un serveur FTP à chaque *push* sur la branche `main`.
 
 ---
 

--- a/howto/fr/stow_dotfiles_howto_FR.md
+++ b/howto/fr/stow_dotfiles_howto_FR.md
@@ -1,6 +1,14 @@
-# Guide pratique : Gérer vos dotfiles avec Git et GNU Stow
+---
+title: Guide pratique : Gérer vos dotfiles avec Git et GNU Stow
+lang: fr
+tags: [git, dotfiles, stow]
+created: 2025-07-27
+updated: 2025-07-27
+---
 
-## Objectif
+# 🚀 Guide pratique : Gérer vos dotfiles avec Git et GNU Stow
+
+## 🎯 Objectif
 
 Ce tutoriel explique comment centraliser et déployer vos fichiers de configuration (“dotfiles”) à l’aide d’un dépôt **Git** et de **GNU Stow**, afin de les partager facilement entre plusieurs machines.
 


### PR DESCRIPTION
## Summary
- add YAML front matter metadata to all English guides
- include a goal section and requirements for each howto

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6886a765a05083268cdc53f8fdb32144